### PR TITLE
Add internals support

### DIFF
--- a/src/jack_server/___internal_clients/net.py
+++ b/src/jack_server/___internal_clients/net.py
@@ -1,0 +1,97 @@
+# type: ignore
+from ctypes import (
+    CDLL,
+    CFUNCTYPE,
+    POINTER,
+    Structure,
+    Union,
+    c_bool,
+    c_char,
+    c_char_p,
+    c_int,
+    c_uint,
+    c_uint32,
+)
+from ctypes.util import find_library
+
+lib_name = find_library("libjacknet")
+
+if not lib_name:
+    raise RuntimeError("Couldn't find libjacknet")
+
+lib = CDLL(lib_name)
+
+
+class jack_slave_t(Structure):
+    _fields_ = [
+        ("audio_input", c_int),
+        ("audio_output", c_int),
+        ("midi_input", c_int),
+        ("midi_output", c_int),
+        ("mtu", c_int),
+        ("time_out", c_int),
+        ("encoder", c_int),
+        ("kbps", c_int),
+        ("latency", c_int),
+    ]
+
+
+class jack_master_t(Structure):
+    _fields_ = [
+        ("audio_input", c_int),
+        ("audio_output", c_int),
+        ("midi_input", c_int),
+        ("midi_output", c_int),
+        ("buffer_size", c_uint32),
+        ("sample_rate", c_uint32),
+        ("master_name", c_char * 256),
+        ("time_out", c_int),
+        ("partial_cycle", c_int),
+    ]
+
+
+class jack_net_slave_t(Structure):
+    pass
+
+
+class jack_net_master_t(Structure):
+    pass
+
+
+jack_net_slave_open = lib.jack_net_slave_open
+jack_net_slave_open.argtypes = [c_char_p, c_int, c_char_p, jack_slave_t, jack_master_t]
+jack_net_slave_open.restype = POINTER(jack_net_slave_t)
+
+jack_net_master_open = lib.jack_net_master_open
+jack_net_master_open.argtypes = [
+    c_char_p,
+    c_int,
+    POINTER(jack_master_t),
+    POINTER(jack_slave_t),
+]
+jack_net_master_open.restype = POINTER(jack_net_master_t)
+
+master = jack_master_t(
+    audio_input=1,
+    audio_output=1,
+    midi_input=1,
+    midi_output=2,
+    buffer_size=10,
+    sample_rate=10,
+    master_name=b"tt",
+    time_out=1,
+    partial_cycle=10,
+)
+slave = jack_slave_t(
+    audio_input=1,
+    audio_output=1,
+    midi_input=1,
+    midi_output=2,
+    mtu=1,
+    time_out=1,
+    encoder=1,
+    kbps=1,
+    latency=1,
+)
+
+jack_net_master_open(b"", 1, master, slave)

--- a/src/jack_server/_internal.py
+++ b/src/jack_server/_internal.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from ctypes import pointer
+
+import jack_server._lib as lib
+from jack_server._parameter import Parameter, get_params_from_jslist
+
+
+class Internal:
+    ptr: pointer[lib.jackctl_internal_t]  # TODO: Params generic
+    params: dict[str, Parameter]
+
+    def __init__(self, ptr: pointer[lib.jackctl_internal_t]) -> None:
+        self.ptr = ptr
+        self._set_params()
+
+    def _set_params(self) -> None:
+        jslist = lib.jackctl_internal_get_parameters(self.ptr)
+        self.params = get_params_from_jslist(jslist)
+
+    @property
+    def name(self) -> str:
+        return lib.jackctl_internal_get_name(self.ptr).decode()
+
+    def set_param_values(self, values: dict[str, int | str | bytes | bool]) -> None:
+        for key, value in values.items():
+            self.params[key].value = value
+
+    def __repr__(self) -> str:
+        return f"<jack_server.Internal name={self.name}>"

--- a/src/jack_server/_lib.py
+++ b/src/jack_server/_lib.py
@@ -87,8 +87,20 @@ jackctl_parameter_get_value.argtypes = [POINTER(jackctl_parameter_t)]
 jackctl_parameter_get_value.restype = jackctl_parameter_value
 
 
-class jackctl_driver_t(Structure):
+class jack_driver_desc_t(Structure):
     pass
+
+
+class jackctl_driver_t(Structure):
+    _fields_ = [
+        ("desc_ptr", POINTER(jack_driver_desc_t)),
+        ("parameters", POINTER(JSList)),
+        ("infos", POINTER(JSList)),
+    ]
+
+    desc_ptr: "pointer[jack_driver_desc_t]"
+    parameters: "pointer[JSList]"
+    infos: "pointer[JSList]"
 
 
 jackctl_driver_get_parameters: Callable[
@@ -102,6 +114,31 @@ jackctl_driver_get_name: Callable[
 ] = lib.jackctl_driver_get_name
 jackctl_driver_get_name.argtypes = [POINTER(jackctl_driver_t)]
 jackctl_driver_get_name.restype = c_char_p
+
+
+class jackctl_internal_t(Structure):
+    _fields_ = [
+        ("desc_ptr", POINTER(jack_driver_desc_t)),
+        ("parameters", POINTER(JSList)),
+        ("refnum", c_int),
+    ]
+
+    desc_ptr: "pointer[jack_driver_desc_t]"
+    parameters: "pointer[JSList]"
+    refnum: int
+
+
+jackctl_internal_get_name: Callable[
+    ["pointer[jackctl_internal_t]"], bytes
+] = lib.jackctl_internal_get_name
+jackctl_internal_get_name.argtypes = [POINTER(jackctl_internal_t)]
+jackctl_internal_get_name.restype = c_char_p
+
+jackctl_internal_get_parameters: Callable[
+    ["pointer[jackctl_internal_t]"], "pointer[JSList]"
+] = lib.jackctl_internal_get_parameters
+jackctl_internal_get_parameters.argtypes = [POINTER(jackctl_internal_t)]
+jackctl_internal_get_parameters.restype = POINTER(JSList)
 
 
 class jackctl_server_t(Structure):
@@ -164,6 +201,21 @@ jackctl_server_get_drivers_list: Callable[
 ] = lib.jackctl_server_get_drivers_list
 jackctl_server_get_drivers_list.argtypes = [POINTER(jackctl_server_t)]
 jackctl_server_get_drivers_list.restype = POINTER(JSList)
+
+jackctl_server_get_internals_list: Callable[
+    ["pointer[jackctl_server_t]"], "pointer[JSList]"
+] = lib.jackctl_server_get_internals_list
+jackctl_server_get_internals_list.argtypes = [POINTER(jackctl_server_t)]
+jackctl_server_get_internals_list.restype = POINTER(JSList)
+
+jackctl_server_load_internal: Callable[
+    ["pointer[jackctl_server_t]", "pointer[jackctl_internal_t]"], bool
+] = lib.jackctl_server_load_internal
+jackctl_server_load_internal.argtypes = [
+    POINTER(jackctl_server_t),
+    POINTER(jackctl_internal_t),
+]
+jackctl_server_load_internal.restype = c_bool
 
 
 PrintFunction = CFUNCTYPE(None, c_char_p)

--- a/src/jack_server/_parameter.py
+++ b/src/jack_server/_parameter.py
@@ -20,7 +20,9 @@ class Parameter:
         return lib.jackctl_parameter_get_name(self.ptr).decode()
 
     @property
-    def value(self) -> int | str | bytes | bool:
+    def value(
+        self,
+    ) -> int | str | bytes | bool:  # TODO: ValueType = int | str | bytes | bool
         val = lib.jackctl_parameter_get_value(self.ptr)
 
         if self.type == 1:
@@ -53,11 +55,11 @@ class Parameter:
             val_obj.ui = int(val)
         elif self.type == 3:
             # JackParamChar
-            assert isinstance(val, str) and len(val) == 1
+            assert isinstance(val, str) and len(val) == 1, (self.name, val)
             val_obj.c = val
         elif self.type == 4:
             # JackParamString
-            assert isinstance(val, bytes)
+            assert isinstance(val, bytes), (self.name, val)
             val_obj.ss = val
         elif self.type == 5:
             # JackParamBool

--- a/src/jack_server/_server.py
+++ b/src/jack_server/_server.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+from copy import copy
 from ctypes import POINTER, pointer
 from typing import Callable
 
 import jack_server._lib as lib
 from jack_server._driver import Driver, SampleRate
+from jack_server._internal import Internal
 from jack_server._jslist import iterate_over_jslist
 from jack_server._parameter import Parameter, get_params_from_jslist
 
@@ -25,19 +27,29 @@ class DriverNotFoundError(JackServerError):
     pass
 
 
+class InternalNotFoundError(JackServerError):
+    pass
+
+
+class InternalNotLoadedError(JackServerError):
+    pass
+
+
 class Server:
     ptr: pointer[lib.jackctl_server_t]
     params: dict[str, Parameter]
     available_drivers: list[Driver]
+    available_internals: list[Internal]
     driver: Driver
     _created: bool
     _opened: bool
     _started: bool
     _dont_garbage_collect: list[object]
 
-    def __init__(
+    def __init__(  # TODO: Allow to change name
         self,
         *,
+        name: str = "default",
         driver: str,
         device: str | None = None,
         rate: SampleRate | None = None,
@@ -51,9 +63,13 @@ class Server:
         self._create()
 
         self._set_params()
+        self.set_name(name)
         self._set_available_drivers()
+        self._set_internals()
 
-        self.driver = self.get_driver_by_name(driver)
+        # self._set_params()
+        # print(self.params["name"])
+        self.driver = self._get_driver_by_name(driver)
 
         if device:
             self.driver.set_device(device)
@@ -131,15 +147,94 @@ class Server:
         iterator = iterate_over_jslist(jslist, POINTER(lib.jackctl_driver_t))
         self.available_drivers = [Driver(ptr) for ptr in iterator]
 
-    def get_driver_by_name(self, name: str) -> Driver:
+    def _set_internals(self) -> None:
+        jslist = lib.jackctl_server_get_internals_list(self.ptr)
+        iterator = iterate_over_jslist(jslist, POINTER(lib.jackctl_internal_t))
+        self.available_internals = [Internal(ptr) for ptr in iterator]
+
+    def _get_driver_by_name(self, name: str) -> Driver:
         for driver in self.available_drivers:
             if driver.name == name:
                 return driver
 
         raise DriverNotFoundError(f"Driver not found: {name}")
 
+    def set_name(self, name: str) -> None:
+        self.params["name"].value = name.encode()
+
     def set_sync(self, sync: bool) -> None:
         self.params["sync"].value = sync
+
+    def _get_internal_by_name(self, name: str) -> Internal:
+        for internal in self.available_internals:
+            if internal.name == name:
+                return internal
+
+        raise InternalNotFoundError(f"Internal not found: {name}")
+
+    def _load_internal(self, internal: Internal) -> None:
+        loaded = lib.jackctl_server_load_internal(self.ptr, internal.ptr)
+        if not loaded:
+            raise InternalNotLoadedError
+
+    def load_netmanager(
+        self,
+        *,
+        ip: str = "225.3.19.154",
+        udp_port: int = 19000,
+        auto_connect: bool = False,
+        auto_save: bool = False,
+    ) -> None:
+        internal = copy(self._get_internal_by_name("netmanager"))
+        internal.set_param_values(
+            {
+                "multicast-ip": ip.encode(),
+                "udp-net-port": udp_port,
+                "auto-connect": auto_connect,
+                "auto-save": auto_save,
+            }
+        )
+
+        self._load_internal(internal)
+
+    def load_netadapter(
+        self,
+        *,
+        ip: str = "225.3.19.154",  # TODO: Check if params are static. Otherwise make DefaultValue()
+        udp_port: int = 19000,
+        mtu: int = 1500,
+        input_ports: int = 2,
+        output_ports: int = 2,
+        opus: int = -1,
+        client_name: str = "'hostname'",
+        transport_sync: int = 0,
+        latency: int = 5,
+        quality: int = 0,
+        ring_buffer: int = 32768,
+        auto_connect: bool = False,
+    ) -> None:
+        internal = copy(self._get_internal_by_name("netadapter"))
+
+        if client_name != "'hostname'":
+            internal.params["client-name"].value = client_name.encode()
+
+        internal.set_param_values(
+            {
+                "multicast-ip": ip.encode(),
+                "udp-net-port": udp_port,
+                "mtu": mtu,
+                "input-ports": input_ports,
+                "output-ports": output_ports,
+                "opus": opus,
+                "transport-sync": transport_sync,
+                "latency": latency,
+                "quality": quality,
+                "ring-buffer": ring_buffer,
+                "auto-connect": auto_connect,
+            }
+        )
+
+        self._load_internal(internal)
 
     def __repr__(self) -> str:
         return f"<jack_server.Server driver={self.driver.name} started={self._started}>"

--- a/testing/master.py
+++ b/testing/master.py
@@ -1,0 +1,6 @@
+from jack_server import Server
+
+master = Server(name="manager", driver="coreaudio", device="BuiltInSpeakerDevice")
+master.start()
+master.load_netmanager(ip="127.0.0.1")
+input()

--- a/testing/slave.py
+++ b/testing/slave.py
@@ -1,0 +1,6 @@
+from jack_server import Server
+
+slave = Server(name="slave", driver="coreaudio", device="BlackHole16ch_UID")
+slave.start()
+slave.load_netadapter(ip="127.0.0.1")
+input()


### PR DESCRIPTION
In this PR internals support is added: generic support and wrappers around `netmanager` and `netadapter` internals.

Initially I created this package to use in private (until it is ready to be published) project that tries to solve my audio networking problem. In addition to JACK server the project uses [JackTrip](https://github.com/jacktrip/jacktrip) to send and receive audio. At some point I decided to try out [NetJack2](https://github.com/jackaudio/jackaudio.github.com/wiki/WalkThrough_User_NetJack2) but it didn't work out.

Let me know if you desperately want this feature implemented in `jack_server`!