### PR TITLE
Add `nperiods` property to `Driver`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ server = jack_server.Server(
     device="BuiltInSpeakerDevice",
     rate=48000,
     period=1024,
+    # nperiods=2  # Work only with `alsa` driver
 )
 server.start()
 
@@ -92,6 +93,12 @@ Sampling rate.
 #### `period: int`
 
 Buffer size.
+
+#### `nperiods: int`
+
+Number of periods. 2 is right for motherboard, PCI, PCI-X, etc.; 3 for USB ([source](https://wiki.archlinux.org/title/JACK_Audio_Connection_Kit)).
+
+Can be helpful when tailoring performance on jittery systems.
 
 #### `params: dict[str, jack_server.Parameter]`
 

--- a/src/jack_server/_driver.py
+++ b/src/jack_server/_driver.py
@@ -49,5 +49,13 @@ class Driver:
     def period(self, __value: int) -> None:
         self.params["period"].value = __value
 
+    @property
+    def nperiods(self) -> int:
+        return cast(int, self.params["nperiods"].value)
+
+    @nperiods.setter
+    def nperiods(self, __value: int) -> None:
+        self.params["nperiods"].value = __value
+
     def __repr__(self) -> str:
         return f"<jack_server.Driver name={self.name}>"

--- a/src/jack_server/_driver.py
+++ b/src/jack_server/_driver.py
@@ -50,11 +50,13 @@ class Driver:
         self.params["period"].value = __value
 
     @property
-    def nperiods(self) -> int:
+    def nperiods(self) -> int:  # pragma: no cover (works only with alsa driver)
         return cast(int, self.params["nperiods"].value)
 
     @nperiods.setter
-    def nperiods(self, __value: int) -> None:
+    def nperiods(
+        self, __value: int
+    ) -> None:  # pragma: no cover (works only with alsa driver)
         self.params["nperiods"].value = __value
 
     def __repr__(self) -> str:

--- a/src/jack_server/_server.py
+++ b/src/jack_server/_server.py
@@ -69,12 +69,16 @@ class Server:
         if not isinstance(realtime, SetByJack):
             self.realtime = realtime
         if not isinstance(device, SetByJack):
-            self.driver.device = device  # pragma: no cover (can't set driver on dummy driver that used in CI)
+            self.driver.device = (
+                device  # pragma: no cover (does not work with dummy driver)
+            )
         if not isinstance(rate, SetByJack):
             self.driver.rate = rate
         if not isinstance(period, SetByJack):
             self.driver.period = period
-        if not isinstance(nperiods, SetByJack):
+        if not isinstance(
+            nperiods, SetByJack
+        ):  # pragma: no cover (works only with alsa driver)
             self.driver.nperiods = nperiods
 
     def _create(

--- a/src/jack_server/_server.py
+++ b/src/jack_server/_server.py
@@ -51,6 +51,7 @@ class Server:
         device: str | SetByJack = SetByJack_,
         rate: SampleRate | SetByJack = SetByJack_,
         period: int | SetByJack = SetByJack_,
+        nperiods: int | SetByJack = SetByJack_,
     ) -> None:
         self._created = False
         self._opened = False
@@ -73,6 +74,8 @@ class Server:
             self.driver.rate = rate
         if not isinstance(period, SetByJack):
             self.driver.period = period
+        if not isinstance(nperiods, SetByJack):
+            self.driver.nperiods = nperiods
 
     def _create(
         self,

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -1,5 +1,3 @@
-import sys
-
 import pytest
 
 from jack_server import Server
@@ -12,11 +10,3 @@ from tests.conftest import check_property
 def test_driver_properties(driver: str, name: str, value: str, param_value: str):
     server = Server(driver=driver)
     check_property(server.driver, name, value, param_value)
-
-
-@pytest.mark.skipif(
-    sys.platform != "linux", reason="nperiods is only supported on Linux"
-)
-def test_driver_nperiods():
-    server = Server(driver="alsa", nperiods=2)
-    check_property(server.driver, name="nperiods", value=2, param_value=2)

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 from jack_server import Server
@@ -10,3 +12,11 @@ from tests.conftest import check_property
 def test_driver_properties(driver: str, name: str, value: str, param_value: str):
     server = Server(driver=driver)
     check_property(server.driver, name, value, param_value)
+
+
+@pytest.mark.skipif(
+    sys.platform != "linux", reason="nperiods is only supported on Linux"
+)
+def test_driver_nperiods():
+    server = Server(driver="alsa", nperiods=2)
+    check_property(server.driver, name="nperiods", value=2, param_value=2)


### PR DESCRIPTION
This will just add the possibility to configure the number of periods used by the underlying soundcard. This can be especially helpfull when tailoring performance on jittery systems.